### PR TITLE
Allow passing extra 'issue search' filters via commandline param

### DIFF
--- a/lib/github-graphql.rb
+++ b/lib/github-graphql.rb
@@ -159,7 +159,7 @@ module GithubGraphql
     return query(qry, vars)
   end
 
-  def self.get_pull_requests_for_login(login)
+  def self.get_pull_requests_for_login(login, extra_filters)
     qry = <<-'GRAPHQL'
       query($queryString: String!) {
         search(query:$queryString, type: ISSUE, first: 100) {
@@ -233,7 +233,7 @@ module GithubGraphql
     GRAPHQL
 
     vars = {
-      queryString: "is:open is:pr author:#{login}"
+      queryString: "is:open is:pr author:#{login} #{extra_filters}"
     }
 
     return query(qry, vars)

--- a/lib/github.rb
+++ b/lib/github.rb
@@ -7,8 +7,8 @@ module Github
     return _pr_data(data["data"]["repository"]["pullRequest"])
   end
 
-  def self.pull_requests_for_login(login)
-    data = GithubGraphql.get_pull_requests_for_login(login)
+  def self.pull_requests_for_login(login, extra_filters)
+    data = GithubGraphql.get_pull_requests_for_login(login, extra_filters)
     return data["data"]["search"]["edges"].map do |edge|
       _pr_data(edge["node"])
     end

--- a/my_prs.rb
+++ b/my_prs.rb
@@ -8,8 +8,14 @@ if $PROGRAM_NAME == __FILE__
     exit(1)
   end
 
+  if ARGV.length > 0
+    extra_filters = ARGV[0]
+  else
+    extra_filters = ""
+  end
+
   login = Github.my_user_login()
 
-  prs = Github.pull_requests_for_login(login)
+  prs = Github.pull_requests_for_login(login, extra_filters)
   Github.puts_multiple_pull_requests(prs)
 end

--- a/team_prs.rb
+++ b/team_prs.rb
@@ -9,7 +9,7 @@ if $PROGRAM_NAME == __FILE__
   end
 
   if ARGV.length < 1 && !ENV["GITHUB_TEAM"]
-    puts "Usage: #{__FILE__} <team name as org/team>"
+    puts "Usage: #{__FILE__} <team name as org/team> <optional extra filters>"
     exit(2)
   end
 
@@ -18,6 +18,12 @@ if $PROGRAM_NAME == __FILE__
   else
     team_name = ENV["GITHUB_TEAM"]
   end
+  if ARGV.length > 1
+    extra_filters = ARGV[1]
+  else
+    extra_filters = ""
+  end
+
   parsed_team = Github.parse_org_and_team(team_name)
 
   team = Github.team_members(parsed_team["org"], parsed_team["team_name"])
@@ -30,7 +36,7 @@ if $PROGRAM_NAME == __FILE__
   puts "│   "
   no_prs = []
   team.each_with_index do |member, i|
-    prs = Github.pull_requests_for_login(member["login"]).reject { |pr| pr["owner"].downcase != parsed_team["org"].downcase }
+    prs = Github.pull_requests_for_login(member["login"], extra_filters).reject { |pr| pr["owner"].downcase != parsed_team["org"].downcase }
 
     if !prs.empty?
       Github.puts_multiple_pull_requests(prs, { prefix: "│   " })


### PR DESCRIPTION
```sh
ruby my_prs.rb "created:>=2019-01-01 -repo:org-name/repo-name"
ruby team_prs.rb $GITHUB_TEAM "created:>=2019-01-01 -repo:org-name/repo-name"
```

will show pull requests created after the specified date and only those not in the repo `org-name/repo-name`