### PR TITLE
Include the login name if a Bot comments/reviews a PR

### DIFF
--- a/lib/github-graphql.rb
+++ b/lib/github-graphql.rb
@@ -138,6 +138,7 @@ module GithubGraphql
               nodes {
                 author {
                   ...userFields
+                  ...botFields
                 }
                 state
               }
@@ -148,6 +149,9 @@ module GithubGraphql
 
       fragment userFields on User {
         name
+        login
+      }
+      fragment botFields on Bot {
         login
       }
     GRAPHQL
@@ -219,6 +223,7 @@ module GithubGraphql
                   nodes {
                     author {
                       ...userFields
+                      ...botFields
                     }
                     state
                   }
@@ -231,6 +236,9 @@ module GithubGraphql
 
       fragment userFields on User {
         name
+        login
+      }
+      fragment botFields on Bot {
         login
       }
     GRAPHQL


### PR DESCRIPTION
Fix bot reviews/comments appearing as `@` (bots such as `/apps/codeclimate`)

![image](https://user-images.githubusercontent.com/6033/87458732-649f7100-c5d8-11ea-9ba7-7b8d0351976d.png)

With this update:

![image](https://user-images.githubusercontent.com/6033/87458833-8b5da780-c5d8-11ea-8500-94c30bc87208.png)
