### PR TITLE
Fix pr.rb output when a review request exists for a team you don't have permission for

### DIFF
--- a/lib/github.rb
+++ b/lib/github.rb
@@ -173,6 +173,8 @@ module Github
     end
 
     pr["reviewRequests"].each do |rr|
+      next if rr.nil?
+
       if color
         puts_with_prefix.call " \e[33m\e[1m●\e[0m  #{rr["user"]}"
       else


### PR DESCRIPTION
team_prs.rb was fixed for this case identified in https://github.com/jasonpenny/prs-ruby/pull/17#discussion_r662583595

this fixes pr.rb for a PR that has a review request for a team that you do not have access to

such as `./pr.rb https://github.com/cornell-dti/clubhub/pull/14`