### PR TITLE
Script to gather old pull requests, grouped by author

### DIFF
--- a/old_prs_by_author.rb
+++ b/old_prs_by_author.rb
@@ -1,0 +1,28 @@
+#!/usr/bin/env ruby
+
+require_relative "lib/github"
+
+if $PROGRAM_NAME == __FILE__
+  if !ENV["GITHUB_ACCESS_TOKEN"]
+    puts "GITHUB_ACCESS_TOKEN environment var needs to be set to a personal access token"
+    exit(1)
+  end
+
+  if ARGV.length != 2
+    puts "Usage: #{__FILE__} <repo> <date>"
+    exit(1)
+  end
+
+  prs = Github.open_pull_requests_for_repo(ARGV[0], "updated:<#{ARGV[1]}")
+  counts = Hash.new(0)
+  prs.each do |pr|
+    key = [pr["author"], pr["authorLogin"]]
+    counts[key] += 1
+  end
+
+  counts
+    .sort_by { |_, val| -val }
+    .each do |(user, login), count|
+    puts "#{count.to_s.rjust(2)} #{user.ljust(42)} https://github.com/#{ARGV[0]}/pulls?q=is%3Aopen+is%3Apr+author%3A#{login}+updated%3A%3C#{ARGV[1]}"
+    end
+end


### PR DESCRIPTION
Finds pull requests last updated before the specified date and groups them by author, with a link to review per author in a browser

```console
$ old_prs_by_author.rb <org>/<repo> 2021-08-18
 7 Author  Name (@github_name)                  https://github.com/<org>/<repo>/pulls?q=is%3Aopen+is%3Apr+author%3Agithub_name+updated%3A%3C2021-08-18
```