### PR TITLE
Update output to include time review-request was created

### DIFF
--- a/lib/github-graphql.rb
+++ b/lib/github-graphql.rb
@@ -134,6 +134,17 @@ module GithubGraphql
                 }
               }
             }
+            timelineItems(last: 100, itemTypes: [REVIEW_REQUESTED_EVENT]) {
+              nodes {
+                ... on ReviewRequestedEvent {
+                  createdAt
+                  requestedReviewer {
+                    ... on User { login }
+                    ... on Team { login: slug }
+                  }
+                }
+              }
+            }
             reviews(last: 100) {
               nodes {
                 author {
@@ -216,6 +227,17 @@ module GithubGraphql
                       ... on Team {
                         name
                         login: slug
+                      }
+                    }
+                  }
+                }
+                timelineItems(last: 100, itemTypes: [REVIEW_REQUESTED_EVENT]) {
+                  nodes {
+                    ... on ReviewRequestedEvent {
+                      createdAt
+                      requestedReviewer {
+                        ... on User { login }
+                        ... on Team { login: slug }
                       }
                     }
                   }

--- a/lib/github.rb
+++ b/lib/github.rb
@@ -60,9 +60,15 @@ module Github
       end
     end
 
+    timeline_events = (pr["timelineItems"] && pr["timelineItems"]["nodes"]) || []
     result["reviewRequests"] = pr["reviewRequests"]["nodes"].map do |rr|
       if !rr["requestedReviewer"].nil?
-        { "user" => name_and_login(rr["requestedReviewer"]) }
+        login = rr["requestedReviewer"]["login"]
+        matching = timeline_events.select do |evt|
+          evt && evt["requestedReviewer"] && evt["requestedReviewer"]["login"] == login
+        end
+        created_at = matching.map { |e| e["createdAt"] }.max
+        { "user" => name_and_login(rr["requestedReviewer"]), "createdAt" => created_at }
       end
     end
 
@@ -181,13 +187,25 @@ module Github
       end
     end
 
+    user_width = pr["reviewRequests"].compact.map { |rr| rr["user"].length }.max || 0
+
     pr["reviewRequests"].each do |rr|
       next if rr.nil?
 
+      time_info = ""
+      if rr["createdAt"]
+        formatted = DateTime.parse(rr["createdAt"])
+          .localtime
+          .strftime("%Y-%m-%d %I:%M %p")
+        time_info = "  #{relative_time_hm(rr["createdAt"])} (#{formatted})"
+      end
+
+      user_padded = rr["user"].ljust(user_width)
+
       if color
-        puts_with_prefix.call " \e[33m\e[1m●\e[0m  #{rr["user"]}"
+        puts_with_prefix.call " \e[33m\e[1m●\e[0m  #{user_padded}#{time_info}"
       else
-        puts_with_prefix.call " ●  #{rr["user"]}"
+        puts_with_prefix.call " ●  #{user_padded}#{time_info}"
       end
     end
   end
@@ -235,6 +253,16 @@ module Github
 
     diff *= 60
     return time_ago(diff, "second")
+  end
+
+  def self.relative_time_hm(dtStr)
+    total_minutes = ((DateTime.now.to_time - DateTime.parse(dtStr).to_time) / 60).to_i
+    total_minutes = 0 if total_minutes < 0
+    days = total_minutes / (60 * 24)
+    hours = (total_minutes / 60) % 24
+    minutes = total_minutes % 60
+    days_str = days > 0 ? format("%2dd", days) : "   "
+    format("%s%02dh%02dm ago", days_str, hours, minutes)
   end
 
   def self.time_ago(diff, period)


### PR DESCRIPTION
Update output to include time review-request was created, in order to easily find PRs that I should follow up on.

Such as:

```console
$ ./my_prs.rb
https://github.com/.../pull/122
Upgrade to Ruby 3.3.11 main..upgrade-to-ruby-3.3
Person 1 (@person1) 17 hours ago (2026-05-19 04:40 PM)

 ±  @person2
 ●  Person 3 (@person3)     17h06m ago (2026-05-19 04:40 PM)
 ●  Person 4 (@person4)     17h06m ago (2026-05-19 04:40 PM)


https://github.com/.../pull/73
Upgrade to Ruby 3.3.11 upgrade-to-ruby-3.3
Person 1 (@person1) 19 hours ago (2026-05-19 02:18 PM)

 ±  @person2
 ✔  Person 5 (@person5)
 ●  Person 4 (@person4)     19h28m ago (2026-05-19 02:18 PM)
 ●  Person 6 (@person6)     19h28m ago (2026-05-19 02:18 PM)


https://github.com/.../pull/82
Upgrade to ruby 3.3 upgrade-to-ruby-3.3
Person 1 (@person1) 22 hours ago (2026-05-19 10:51 AM)

 ●  Person 4 (@person4)     22h55m ago (2026-05-19 10:51 AM)
 ●  Person 7 (@person7)     22h55m ago (2026-05-19 10:51 AM)


https://github.com/.../pull/17
Remove no-longer-used buildkite pipeline using EOL Ruby 3.2 remove-buildkite-pipeline
Person 1 (@person1) 1 day ago (2026-05-18 03:18 PM)

 ✔  @person2
 ✔  Person 8 (@person8)
 ●  Person 3 (@person3)   1d18h29m ago (2026-05-18 03:18 PM)
```