### PR TITLE
Exclude PRs from archived repos

### DIFF
--- a/lib/github-graphql.rb
+++ b/lib/github-graphql.rb
@@ -267,7 +267,7 @@ module GithubGraphql
     GRAPHQL
 
     vars = {
-      queryString: "is:open is:pr #{search}"
+      queryString: "is:open is:pr archived:false #{search}"
     }
 
     return query(qry, vars)


### PR DESCRIPTION
Archived Repos freeze open pull requests, etc. which means an open PR will always be visible unless filtered out.

This updates the API search to filter out `archived` repos